### PR TITLE
Fixed access control issues for /leaderboard/leaderboard

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
@@ -51,8 +51,8 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
                 .antMatchers("/clubusers/**").hasAnyRole("ADMIN", "CD")
                 .antMatchers(HttpMethod.POST,"/memberreactions/**").authenticated() //YDP can post reactions
                 .antMatchers("/memberreactions/**").hasAnyRole("ADMIN","CD") //YDP cannot GET reactions
-                .antMatchers(HttpMethod.GET,"/leaderboard/**").authenticated()
-                .antMatchers("/leaderboard/**").hasAnyRole("ADMIN","CD")
+                .antMatchers(HttpMethod.GET,"/leaderboard/leaderboard").authenticated()
+                .antMatchers("/leaderboard/leaderboard").hasAnyRole("ADMIN","CD")
                 .antMatchers(HttpMethod.GET,"/memberreactions/alert").authenticated()
                 .antMatchers("/memberreactions/alert").hasAnyRole("ADMIN","CD","YDP")
                 .antMatchers(HttpMethod.GET,"/members/**").authenticated()


### PR DESCRIPTION
Description
Attempts to fix the access control issues for endpoint: /leaderboard/leaderboard
What work was done?  
edited the security config to allow access to the /leaderboard/leaderboard endpoint
Why was this work done?  
/leaderboard/leaderboard was returning a 403 for authenticated users

[x] New feature (non-breaking change which adds functionality)
Change Status  
[x] Completed, ready to review and merge  

Checklist
[x] My code follows the style guidelines of this project  
[x] I have performed a self-review of my own code  
[] My code has been reviewed by at least one peer  
[] I have commented my code, particularly in hard-to-understand areas  
[] I have made corresponding changes to the documentation  
[x] My changes generate no new warnings  
[x] There are no merge conflicts