### PR TITLE
Adds fields to the json served by /clubactivities/feedback

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/controllers/ClubActivityController.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/controllers/ClubActivityController.java
@@ -4,12 +4,9 @@ import com.lambdaschool.oktafoundation.models.ClubActivities;
 import com.lambdaschool.oktafoundation.models.MemberReactions;
 import com.lambdaschool.oktafoundation.repository.MemberReactionRepository;
 import com.lambdaschool.oktafoundation.repository.ReactionRepository;
-import com.lambdaschool.oktafoundation.services.ActivityService;
-import com.lambdaschool.oktafoundation.services.ClubActivityService;
-import com.lambdaschool.oktafoundation.services.ReactionService;
+import com.lambdaschool.oktafoundation.services.*;
 import com.lambdaschool.oktafoundation.views.*;
 import io.swagger.annotations.ApiOperation;
-import com.lambdaschool.oktafoundation.services.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +29,9 @@ public class ClubActivityController {
      */
     @Autowired
     private ClubActivityService clubActivityService;
+
+    @Autowired
+    private ClubService clubService;
 
     @Autowired
     private MemberReactionRepository memberReactionRepository;
@@ -95,7 +95,6 @@ public class ClubActivityController {
         for(ClubActivityFeedbackData clubActivityFeedback: memberReactionsNotCheckInOut) {
             /** boolean used to determine whether or not the club is alread in feedbackReactionsList*/
             boolean clubInfeedbackReactionsList = false;
-//            check if clubActivityFeedback.getClubid() is in feedbackReactionsList
             for(ClubActivityFeedbackReactions feedbackReaction: feedbackReactionsList) {
                 /** If the club is in feedbackReactionsList then check to see if the current looked activity is associated with that club */
                 if(feedbackReaction.getClubid() == clubActivityFeedback.getClubid()) {
@@ -153,11 +152,13 @@ public class ClubActivityController {
                 ClubActivityFeedback newClubActivityFeedback = new ClubActivityFeedback();
 
                 newClubActivityFeedback.setClubid(feedbackReactions.getClubid());
+                newClubActivityFeedback.setClubname(clubService.findClubById(feedbackReactions.getClubid()).getClubname());
                 List<ActivityReactionRating> newRatingList = new ArrayList<>();
 
                 for(ActivityReaction activityReaction: feedbackReactions.getActivityreactions()) {
                     ActivityReactionRating newActivityReactionRating = new ActivityReactionRating();
                     newActivityReactionRating.setActivityid(activityReaction.getActivityid());
+                    newActivityReactionRating.setActivityname(activityService.findActivityById(activityReaction.getActivityid()).getActivityname());
                     double reactionSum = 0.0;
                     for (Integer val: activityReaction.getReactionints()) {
                         reactionSum += (double) val;

--- a/src/main/java/com/lambdaschool/oktafoundation/views/ActivityReaction.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/views/ActivityReaction.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class ActivityReaction {
     List<Integer> reactionints;
     long activityid;
+    String activityname;
 
     public ActivityReaction() {
     }
@@ -15,6 +16,14 @@ public class ActivityReaction {
 
     public void setActivityid(long activityid) {
         this.activityid = activityid;
+    }
+
+    public String getActivityname() {
+        return activityname;
+    }
+
+    public void setActivityname(String activityname) {
+        this.activityname = activityname;
     }
 
     public List<Integer> getReactionints() {

--- a/src/main/java/com/lambdaschool/oktafoundation/views/ActivityReactionRating.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/views/ActivityReactionRating.java
@@ -3,6 +3,7 @@ package com.lambdaschool.oktafoundation.views;
 public class ActivityReactionRating {
 
     long activityid;
+    String activityname;
     double activityrating;
 
     public ActivityReactionRating() {
@@ -14,6 +15,14 @@ public class ActivityReactionRating {
 
     public void setActivityid(long activityid) {
         this.activityid = activityid;
+    }
+
+    public String getActivityname() {
+        return activityname;
+    }
+
+    public void setActivityname(String activityname) {
+        this.activityname = activityname;
     }
 
     public double getActivityrating() {

--- a/src/main/java/com/lambdaschool/oktafoundation/views/ClubActivityFeedback.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/views/ClubActivityFeedback.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class ClubActivityFeedback {
     long clubid;
+    String clubname;
     List<ActivityReactionRating> activityReactionRatings;
 
     public ClubActivityFeedback() {
@@ -23,6 +24,14 @@ public class ClubActivityFeedback {
 
     public void setActivityReactionRatings(List<ActivityReactionRating> activityReactionRatings) {
         this.activityReactionRatings = activityReactionRatings;
+    }
+
+    public String getClubname() {
+        return clubname;
+    }
+
+    public void setClubname(String clubname) {
+        this.clubname = clubname;
     }
 }
 


### PR DESCRIPTION
Description
The frontend needed a bit more info on the clubs and activities than what we were originally passing. This PR adds that info to the return object
What work was done?  
changed the views to grab the clubname and activityname associated with each feedback rating
Why was this work done?  
The frontend needed a bit more info on the clubs and activities than what we were originally passing.

[x] New feature (non-breaking change which adds functionality)
Change Status  
[x] Completed, ready to review and merge  
Has This Been Tested  
[ ] Yes
Checklist
[X] My code follows the style guidelines of this project  
[X] I have performed a self-review of my own code  
[X] My code has been reviewed by at least one peer  
[] I have commented my code, particularly in hard-to-understand areas  
[] I have made corresponding changes to the documentation  
[X] My changes generate no new warnings  
[X] There are no merge conflicts (edited) 